### PR TITLE
Changing the error messages returned from failed logins

### DIFF
--- a/app/config/passport/local-login.js
+++ b/app/config/passport/local-login.js
@@ -17,11 +17,11 @@ module.exports = function(salt) {
           return done(err);
 
         if (!rows.length) {
-          return done(null, false, req.flash('flashMessage', 'Coult not find a user with that email address.'));
+          return done(null, false, req.flash('flashMessage', 'Invalid login details'));
         }
 
         if (bcrypt.hashSync(password, salt) !== rows[0].password) {
-          return done(null, false, req.flash('flashMessage', 'Oops! Wrong password.'));
+          return done(null, false, req.flash('flashMessage', 'Invalid login details'));
         }
 
         return done(null, rows[0]);


### PR DESCRIPTION
Return less information from unsuccessful login attempts.  Returning "invalid password" would allow an attacker to determine that they had guessed an existing username/email address.
