### PR TITLE
Switch to using a MySQL connection pool

### DIFF
--- a/app/config/connection.js
+++ b/app/config/connection.js
@@ -1,12 +1,10 @@
 const mysql = require('mysql');
 
-const connection = mysql.createConnection({
+const pool = mysql.createPool({
   host     : 'localhost',
   user     : 'root',
   password : '',
   database : 'hammer_test'
 });
 
-connection.connect();
-
-module.exports = connection;
+module.exports = pool;


### PR DESCRIPTION
The `mysql` package has built in connection pooling which will automatically open connections as needed (up to a maximum) and recycle them for requests.  The interface for basic query calls is identical (`pool.query()`), but you gain the ability to perform multiple queries in parallel spread across multiple connections (especially if your mysql server is threaded across on multiple cores). The app won't open the first db connection until it actually needs it.

It also ensures that you'll be less likely to have a request delayed because another request is using the connection.

The only time you need an actual explicit connection is for transactions and streams, and it's pretty easy to get one from the pool.

You might consider also swapping the `mysql` package for [`mysql2`](https://www.npmjs.com/package/mysql2). It's a drop in replacement, is faster, more secure, and supports prepared statements with proper data bound parameters (`mysql` only does query string substitution) & named parameters.
